### PR TITLE
Changed idle_time_limit to 5 minutes

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ properties. All times are in seconds.
 > The amount of time that can pass between two pressed keys, before the plugin
 > considers it a new session, and starts all timers and counters over.
 >
-> Defaults to 10 seconds.
+> Defaults to 300 seconds (5 minutes).
 
 ### `.settings.lock_time_out`
 

--- a/src/Kaleidoscope/TypingBreaks.cpp
+++ b/src/Kaleidoscope/TypingBreaks.cpp
@@ -23,7 +23,7 @@
 namespace kaleidoscope {
 
 TypingBreaks::settings_t TypingBreaks::settings = {
-  .idle_time_limit = 10,  //  10s
+  .idle_time_limit = 300, //  5m
   .lock_time_out = 2700,  //  45m
   .lock_length = 300,    //   5m
   .left_hand_max_keys = 0,


### PR DESCRIPTION
I changed `idle_time_limit` from ten seconds to five minutes (equal to `lock_length`). Ten seconds seemed way too short; with the defaults, most people would probably never get their keyboards locked because they would have to type continuously for 45 minutes without ever going more than ten seconds without pressing a key.

Fixes #5