### PR TITLE
Set lock_start_time to last_key_time when locking the keyboard

### DIFF
--- a/src/Kaleidoscope/TypingBreaks.cpp
+++ b/src/Kaleidoscope/TypingBreaks.cpp
@@ -95,7 +95,7 @@ Key TypingBreaks::eventHandlerHook(Key mapped_key, byte row, byte col, uint8_t k
     // Is the session longer than lock_time_out?
     if (millis() - session_start_time_ >= lock_time_out) {
       // Yeah, it is.
-      lock_start_time_ = millis();
+      lock_start_time_ = last_key_time_;
       TypingBreak(true);
       return Key_NoKey;
     }


### PR DESCRIPTION
By starting the lockout end timer at the moment of the last keypress
instead of the current time, the effective time of the lockout is
reduced by the amount of time the user has already been idle at the
time the lockout begins. Basically, the user gets credit for time
already spent not typing.

Partially addresses #6